### PR TITLE
Add support for Accumulo 1.6 and preserve backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Ansible role for installing [Apache Accumulo](https://accumulo.apache.org/).
 ## Role Variables
 
 - `accumulo_version` - Accumulo version.
-- `accumulo_mirror` - A mirror for the Accumulo packages (default: `http://www.webhostingjams.com/mirror/apache`)
+- `accumulo_mirror` - A mirror for the Accumulo packages (default: `http://apache.mirrors.lucidnetworks.net`)
 - `accumulo_conf_dir` - Configuration directory for Accumulo (default: `/etc/accumulo/conf`)
 - `accumulo_log_dir` - Log directory for Accumulo (default: `/var/log/accumulo`)
 - `accumulo_leader` - Flag to determine if a node is an Accumulo leader (default: False)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-accumulo_version: "1.5.2"
-accumulo_mirror: "http://www.webhostingjams.com/mirror/apache"
+accumulo_version: "1.6.*"
+accumulo_mirror: "http://apache.mirrors.lucidnetworks.net"
 accumulo_conf_dir: "/etc/accumulo/conf"
 accumulo_log_dir: "/var/log/accumulo"
 accumulo_leader: False

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,6 +1,9 @@
 ---
 - hosts: all
 
+  vars:
+    java_version: "7u75-*"
+
   pre_tasks:
     - name: Update APT cache
       apt: update_cache=yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing Accumulo.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.2
+  min_ansible_version: 1.8
   platforms:
   - name: Ubuntu
     versions:

--- a/tasks/accumulo-1-5.yml
+++ b/tasks/accumulo-1-5.yml
@@ -1,0 +1,33 @@
+---
+- name: Download Accumulo packages
+  get_url: url="{{ accumulo_mirror }}/accumulo/{{ accumulo_version }}/accumulo-{{ accumulo_version }}-{{ item }}.deb"
+           dest="/usr/local/src/accumulo-{{ accumulo_version }}-{{ item }}.deb"
+  with_items:
+    - bin
+    - native
+
+- name: Install Accumulo dependencies
+  apt: pkg=g++-multilib state=present
+
+- name: Install Accumulo
+  command: "dpkg --ignore-depends=hadoop,zookeeper -i /usr/local/src/accumulo-{{ accumulo_version }}-bin.deb"
+  args:
+    creates: "{{ accumulo_conf_dir }}"
+
+- name: Install Accumulo native libraries
+  command: "dpkg --ignore-depends=hadoop,zookeeper -i /usr/local/src/accumulo-{{ accumulo_version }}-native.deb"
+  args:
+    creates: "/usr/lib/accumulo/server/src/main/c++"
+
+- name: Fix Accumulo native library post-install script
+  lineinfile: dest="/var/lib/dpkg/info/accumulo-native.postinst"
+              regexp="^cd /usr/lib/accumulo"
+              line="cd /usr/lib/accumulo/server/src/main/c++"
+              state=present
+  register: fix_accumulo_post_install
+
+- name: Build Accumulo native libraries
+  command: dpkg-reconfigure accumulo-native
+  args:
+    creates: /usr/lib/accumulo/lib/native/map/libNativeMap-Linux-amd64-64.so
+  when: fix_accumulo_post_install | changed

--- a/tasks/accumulo-1-6.yml
+++ b/tasks/accumulo-1-6.yml
@@ -1,0 +1,15 @@
+---
+- name: Configure the PackageCloud APT key
+  apt_key: url=https://packagecloud.io/gpg.key state=present
+
+- name: Configure the PackageCloud APT repositories
+  apt_repository: repo="deb https://packagecloud.io/azavea/accumulo/ubuntu/ {{ ansible_distribution_release }} main"
+                  state=present
+
+- name: Install Accumulo
+  apt: pkg=accumulo={{ accumulo_version }} state=present
+
+- name: Build Accumulo native libraries
+  command: "/usr/lib/accumulo/bin/build_native_library.sh"
+  args:
+    creates: "/usr/lib/accumulo/lib/native/libaccumulo.so"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,38 +6,10 @@
         shell=/bin/false
         state=present
 
-- name: Download Accumulo packages
-  get_url: url="{{ accumulo_mirror }}/accumulo/{{ accumulo_version }}/accumulo-{{ accumulo_version }}-{{ item }}.deb"
-           dest="/usr/local/src/accumulo-{{ accumulo_version }}-{{ item }}.deb"
-  with_items:
-    - bin
-    - native
-
-- name: Install Accumulo dependencies
-  apt: pkg=g++-multilib state=present
-
-- name: Install Accumulo
-  command: "dpkg --ignore-depends=hadoop,zookeeper -i /usr/local/src/accumulo-{{ accumulo_version }}-bin.deb"
-  args:
-    creates: "{{ accumulo_conf_dir }}"
-
-- name: Install Accumulo native libraries
-  command: "dpkg --ignore-depends=hadoop,zookeeper -i /usr/local/src/accumulo-{{ accumulo_version }}-native.deb"
-  args:
-    creates: "/usr/lib/accumulo/server/src/main/c++"
-
-- name: Fix Accumulo native library post-install script
-  lineinfile: dest="/var/lib/dpkg/info/accumulo-native.postinst"
-              regexp="^cd /usr/lib/accumulo"
-              line="cd /usr/lib/accumulo/server/src/main/c++"
-              state=present
-  register: fix_accumulo_post_install
-
-- name: Build Accumulo native libraries
-  command: dpkg-reconfigure accumulo-native
-  args:
-    creates: /usr/lib/accumulo/lib/native/map/libNativeMap-Linux-amd64-64.so
-  when: fix_accumulo_post_install | changed
+- include: accumulo-1-5.yml
+  when: accumulo_version | version_compare('1.6', '<')
+- include: accumulo-1-6.yml
+  when: accumulo_version | version_compare('1.6', '>=')
 
 - name: Ensure Accumulo directories are owned by Accumulo user
   file: path={{ item }}


### PR DESCRIPTION
This change splits the tasks for installing Accumulo by version number. Versions lower than 1.6 use the previous installation method (direct Debian package download from an Accumulo mirror), while versions 1.6 and higher use a PackageCloud APT repository that includes a custom Accumulo 1.6 package.

The custom Accumulo 1.6 package was assembled based on the existing Accumulo 1.5 package using FPM.

See also:
- https://github.com/jordansissel/fpm
- https://gist.github.com/hectcastro/a401bcbd11e412133b3d

Attempts to resolve #1.
